### PR TITLE
Allow double-equals with null checks

### DIFF
--- a/tslint.js
+++ b/tslint.js
@@ -53,7 +53,8 @@ module.exports = {
     ], // 13.2
     'no-increment-decrement': true, // 13.6
     'triple-equals': [
-      true
+      true,
+      "allow-null-check"
     ], // 15.1
     // 'no-boolean-literal-compare': true, // 15.3  disabled by https://github.com/Microsoft/vscode-tslint/issues/70
     // 'strict-boolean-expressions': true, // 15.3  disabled by https://github.com/Microsoft/vscode-tslint/issues/70


### PR DESCRIPTION
Fixes https://github.com/progre/tslint-config-airbnb/issues/13