### PR TITLE
Avoid conflict between object-shorthand-properties-first and object-literal-sort-key 

### DIFF
--- a/tslint.js
+++ b/tslint.js
@@ -10,7 +10,8 @@ module.exports = {
     'prefer-const': true, // 2.1, 13.1
     'no-var-keyword': true, // 2.2
     'object-literal-shorthand': true, // 3.3, 3.4
-    'object-shorthand-properties-first': true, // 3.5
+    'object-shorthand-properties-first': false, // 3.5
+    'object-literal-sort-keys': [true, 'shorthand-first'],
     'object-literal-key-quotes': [true, 'as-needed'], // 3.6
     'prefer-array-literal': true, // 4.1
     quotemark: [


### PR DESCRIPTION
Problem: when both `object-shorthand-properties-first` and `object-literal-sort-key ` are used together, there are cases that would never be correct before. E.g:

```ts
const a = 'a'
const c = 'c'

const obj = {
  a,
  b: 'b',
  c, // If I leave here, object-shorthand-properties-first complains. if I move to be first, object-literal-sort-key will complain.
}
```

The rules conflict. There isn't a single field ordering that matches both rules, resulting on a non-fixable warning. 

That is fixable since tslint v5.9.0 with the addition of the `shorthand-first` property.
See: https://github.com/palantir/tslint/issues/3606 and https://github.com/palantir/tslint/pull/3607

> PS: I did not tested this code change. I edited directly on github. I found it weird that there isn't a dependency on tslint on this project. So not sure if object-literal-sort-keys works here.