### PR TITLE
Replace no-var-self with no-this-assignment

### DIFF
--- a/tslint.js
+++ b/tslint.js
@@ -92,7 +92,7 @@ module.exports = {
       }, // 23.1
     ],
     'variable-name': [true, 'check-format'], // 23.2
-    'no-var-self': true, // 23.5
+    'no-this-assignment': true, // 23.5
     'import-name': true, // 23.6
   },
 };


### PR DESCRIPTION
The no-var-self rule has been deprecated in tslint. It has been replaced with the 'no-this-assignment' flag. Recent versions of tslint have started emitting warnings when using no-var-self.

Resolves #26.  