### PR TITLE
Add react-a11y-* rules.

### DIFF
--- a/tslint.js
+++ b/tslint.js
@@ -94,5 +94,17 @@ module.exports = {
     'variable-name': [true, 'check-format'], // 23.2
     'no-this-assignment': true, // 23.5
     'import-name': true, // 23.6
+    'react-a11y-anchors': true,
+    'react-a11y-aria-unsupported-elements': true,
+    'react-a11y-event-has-role': true,
+    'react-a11y-image-button-has-alt': true,
+    'react-a11y-img-has-alt': true,
+    'react-a11y-lang': true,
+    'react-a11y-props': true,
+    'react-a11y-proptypes': true,
+    'react-a11y-role-has-required-aria-props': true,
+    'react-a11y-role-supports-aria-props': true,
+    'react-a11y-role': true,
+    'react-a11y-tabindex-no-positive': true,
   },
 };


### PR DESCRIPTION
Fixes #37.

Adds almost all of `react-a11y-*` rules from [`tslint-microsoft-contrib`](https://github.com/Microsoft/tslint-microsoft-contrib) as they match https://github.com/evcohen/eslint-plugin-jsx-a11y (and https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb/rules/react-a11y.js).

Only exceptions are:
  * `react-a11y-titles`
  * `react-a11y-meta`

which have no equivalent in the eslint rules.