### PR TITLE
Fix 404 link to tslint docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NPM version](https://img.shields.io/npm/v/tslint-config-airbnb.svg?style=flat)](https://www.npmjs.com/package/tslint-config-airbnb)
 [![Downloads](http://img.shields.io/npm/dm/tslint-config-airbnb.svg?style=flat)](https://npmjs.org/package/tslint-config-airbnb)
 
-> A [TSLint config](https://palantir.github.io/tslint/usage/tslint-json/) for [Airbnb JavaScript Style Guide](https://github.com/airbnb/javascript)
+> A [TSLint config](https://palantir.github.io/tslint/usage/configuration/) for [Airbnb JavaScript Style Guide](https://github.com/airbnb/javascript)
 
 ## Installation
 


### PR DESCRIPTION
There is a 404 link in the README to:

* https://palantir.github.io/tslint/usage/tslint-json/

This PR changes it to:

* https://palantir.github.io/tslint/usage/configuration/

It fixes issue #39.
