### PR TITLE
Update trailing-comma rule to match ES sepc

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "Apache-2.0",
   "main": "tslint.js",
   "peerDependencies": {
-    "tslint": "^5.5.0"
+    "tslint": "^5.8.0"
   },
   "repository": "github:progre/tslint-config-airbnb",
   "scripts": {

--- a/tslint.js
+++ b/tslint.js
@@ -82,6 +82,7 @@ module.exports = {
       {
         multiline: 'always',
         singleline: 'never',
+        esSpecCompliant: true,
       },
     ], // 20.2
     semicolon: [true, 'always'], // 21.1


### PR DESCRIPTION
Since TS v2.9 trailing comma is not allowed after rest parameters.
See: https://github.com/Microsoft/TypeScript/pull/22262

This PR is just aligning with new TS requirement to avoid conflicts.