### PR TITLE
Remove the deprecated rule "no-unused-variable"

### DIFF
--- a/tslint.js
+++ b/tslint.js
@@ -43,7 +43,6 @@ module.exports = {
     'no-duplicate-imports': true, // 10.4
     'one-variable-per-declaration': [true, 'ignore-for-loop'], // 13.2
     'no-increment-decrement': true, // 13.6
-    "no-unused-variable": true, // 13.8
     'triple-equals': [true, 'allow-null-check'], // 15.1
     'no-boolean-literal-compare': true, // 15.3
     curly: [true, 'ignore-same-line'], // 16.1


### PR DESCRIPTION
The commit fixes the issue #54

See more information about it available here, from the tslint repository:
https://github.com/palantir/tslint/issues/4046

Normally, it's simply like a revert of the PR #42 