### PR TITLE
chore: update deprecated ms-contrib rules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2134,12 +2134,12 @@
       }
     },
     "resolve": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+      "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "^1.0.6"
       }
     },
     "resolve-from": {
@@ -2374,9 +2374,9 @@
       "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tslint": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
-      "integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.12.1.tgz",
+      "integrity": "sha512-sfodBHOucFg6egff8d1BvuofoOQ/nOeYNfbp7LDlKBcLNrL3lmS5zoiDGyOMdT7YsEXAwWpTdAHwOGOc8eRZAw==",
       "dev": true,
       "requires": {
         "babel-code-frame": "^6.22.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@commitlint/config-conventional": "^7.1.2",
     "conventional-changelog-cli": "^2.0.11",
     "husky": "^1.1.4",
-    "tslint": "^5.11.0",
+    "tslint": "^5.12.0",
     "typescript": "^3.1.6"
   },
   "homepage": "https://github.com/progre/tslint-config-airbnb/#readme",
@@ -28,7 +28,7 @@
   "license": "Apache-2.0",
   "main": "tslint.js",
   "peerDependencies": {
-    "tslint": "^5.11.0"
+    "tslint": "^5.12.0"
   },
   "repository": "github:progre/tslint-config-airbnb",
   "scripts": {

--- a/tslint.js
+++ b/tslint.js
@@ -22,7 +22,7 @@ module.exports = {
     ], // 6.1, 6.5
     'prefer-template': true, // 6.3
     'no-eval': true, // 6.4
-    'no-function-constructor-with-string-args': true, // 7.10
+    'function-constructor': true, // 7.10
     'space-before-function-paren': [
       true,
       {
@@ -45,7 +45,7 @@ module.exports = {
     ], // 8.4
     'no-duplicate-imports': true, // 10.4
     'one-variable-per-declaration': [true, 'ignore-for-loop'], // 13.2
-    'no-increment-decrement': true, // 13.6
+    'increment-decrement': true, // 13.6
     'triple-equals': [true, 'allow-null-check'], // 15.1
     'no-boolean-literal-compare': true, // 15.3
     curly: [true, 'ignore-same-line'], // 16.1


### PR DESCRIPTION
`tslint-microsoft-contrib` [deprecated](https://github.com/Microsoft/tslint-microsoft-contrib/pull/686) some of their rules that were added directly to TSLint in [5.12.0](https://github.com/palantir/tslint/releases/tag/5.12.0).

[`no-function-constructor-with-string-args`](https://github.com/Microsoft/tslint-microsoft-contrib/blob/master/src/noFunctionConstructorWithStringArgsRule.ts#L20) -> [`function-constructor`](https://palantir.github.io/tslint/rules/function-constructor/)
[`no-increment-decrement`](https://github.com/Microsoft/tslint-microsoft-contrib/blob/master/src/noIncrementDecrementRule.ts#L37) -> [`increment-decrement`](https://palantir.github.io/tslint/rules/increment-decrement)