### PR TITLE
Fix ESLint migration instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 ```bash
 $ npm uninstall tslint tslint-config-airbnb
 $ npm uninstall typescript-tslint-plugin
-$ npm install --dev eslint @typescript-eslint/eslint-plugin eslint-config-airbnb
+$ npm install --save-dev eslint @typescript-eslint/parser @typescript-eslint/eslint-plugin eslint-config-airbnb
 $ npx install-peerdeps --dev eslint-config-airbnb
 ```
 


### PR DESCRIPTION
* Fix npm install `--save-dev` option
* Add [at]typescript-eslint/parser dependency